### PR TITLE
Bugfix: test_period_shift_is_consistent.sql

### DIFF
--- a/macros/generic_tests/test_period_shift_is_consistent.sql
+++ b/macros/generic_tests/test_period_shift_is_consistent.sql
@@ -22,8 +22,8 @@ Argumente:
     Z.B. `-1` um zum Vormonat zu gehen
 * --------------------------------------------------------------------------- */
 
-{% test format_like(model, compare_model, filter_condition=None) %}
-  {{ return(adapter.dispatch('period_shift_is_consistent', 'lf_utils')(model, compare_model, filter_condition)) }}
+{% test period_shift_is_consistent(model, column_name, column_to_compare_with, index_columns, date_column, shift_amount, shift_unit) %}
+  {{ return(adapter.dispatch('period_shift_is_consistent', 'lf_utils')(model, column_name, column_to_compare_with, index_columns, date_column, shift_amount, shift_unit)) }}
 {% endtest %}
 
 {% test default__period_shift_is_consistent(


### PR DESCRIPTION
### Changes to macro test:
* Replaced the `format_like` test with `period_shift_is_consistent`, which now accepts additional parameters (`column_name`, `column_to_compare_with`, `index_columns`, `date_column`, `shift_amount`, `shift_unit`) to provide more flexibility and precision in testing period shifts.