### PR TITLE
v0.4.0

### DIFF
--- a/.github/workflows/duckdb.yml
+++ b/.github/workflows/duckdb.yml
@@ -12,24 +12,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
 
-      - name: Install dbt dependencies
+      - name: Create python venv with lf_py_stack
         run: |
-          pip install dbt-duckdb
-          export DBT_PROJECT_DIR=./unit_tests
-          dbt deps
+            uv venv --python 3.12
+            source .venv/bin/activate
+            uv pip install git+https://github.com/linkFISH-Consulting/python-dbt-stack
+
+      - name: Dbt deps
+        run: |
+            source .venv/bin/activate
+            export DBT_PROJECT_DIR=./unit_tests
+            dbt deps
 
       - name: Run dbt test
         run: |
-          set -a
-          source config/.env.cicd
-          set +a
+          source .venv/bin/activate
+          set -a; source config/.env.cicd; set +a
           mkdir -p $(dirname $LF_UTILS__DUCKDB_DATAMART_PATH)
           export DBT_PROFILE=lf_utils_duckdb
           export DBT_PROJECT_DIR=./unit_tests

--- a/.github/workflows/mssql.yml
+++ b/.github/workflows/mssql.yml
@@ -23,12 +23,22 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Create python venv with lf_py_stack
+        run: |
+            uv venv --python 3.12
+            source .venv/bin/activate
+            uv pip install git+https://github.com/linkFISH-Consulting/python-dbt-stack
+
+      - name: Dbt deps
+        run: |
+            source .venv/bin/activate
+            export DBT_PROJECT_DIR=./unit_tests
+            dbt deps
 
       - name: Install ODBC Driver
         run: |
@@ -50,17 +60,10 @@ jobs:
           echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc
           source ~/.bashrc
 
-      - name: Install dbt dependencies
-        run: |
-          pip install dbt-sqlserver
-          export DBT_PROJECT_DIR=./unit_tests
-          dbt deps
-
       - name: Wait for MSSQL to be ready
         run: |
-          set -a
-          source config/.env.cicd
-          set +a
+          set -a; source config/.env.cicd; set +a
+          export DBT_PROJECT_DIR=./unit_tests
           for i in {1..10}; do
             if /opt/mssql-tools18/bin/sqlcmd -S "$LF_UTILS__MSSQL_HOST" -U "$LF_UTILS__MSSQL_USER" -P "$LF_UTILS__MSSQL_PASSWORD" -Q "SELECT 1" -C; then
               echo "MSSQL is ready!"
@@ -74,9 +77,8 @@ jobs:
 
       - name: Run dbt test
         run: |
-          set -a
-          source config/.env.cicd
-          set +a
+          source .venv/bin/activate
+          set -a; source config/.env.cicd; set +a
           export DBT_PROFILE=lf_utils_mssql
           export DBT_PROJECT_DIR=./unit_tests
           dbt debug

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -24,24 +24,27 @@ jobs:
           --health-cmd="pg_isready -U postgres" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
 
-      - name: Install dbt dependencies
+      - name: Create python venv with lf_py_stack
         run: |
-          pip install dbt-postgres
-          export DBT_PROJECT_DIR=./unit_tests
-          dbt deps
+            uv venv --python 3.12
+            source .venv/bin/activate
+            uv pip install git+https://github.com/linkFISH-Consulting/python-dbt-stack
+
+      - name: Dbt deps
+        run: |
+            source .venv/bin/activate
+            export DBT_PROJECT_DIR=./unit_tests
+            dbt deps
 
       - name: Wait for Postgres to be ready
         run: |
-          set -a
-          source config/.env.cicd
-          set +a
+          source .venv/bin/activate
+          set -a; source config/.env.cicd; set +a
           for i in {1..10}; do
             if pg_isready -h "$LF_UTILS__POSTGRES_HOST" -p "$LF_UTILS__POSTGRES_PORT" -U "$LF_UTILS__POSTGRES_USER"; then
               echo "Postgres is ready!"
@@ -57,9 +60,8 @@ jobs:
 
       - name: Run dbt test
         run: |
-          set -a
-          source config/.env.cicd
-          set +a
+          source .venv/bin/activate
+          set -a; source config/.env.cicd; set +a
           export DBT_PROFILE=lf_utils_postgres
           export DBT_PROJECT_DIR=./unit_tests
           dbt debug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0] - Upcoming
+## [0.4.0] - 2026-06-17
 
 ### Added
 
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - we should no longer get warnings for overriding the `generate_alias_name` and `generate_schema_name` builtin macros
+
+### Removed
+
+- `dbt_unittest` dependency, in the end we never used it.
 
 ## [0.3.0] - 2026-02-04
 
@@ -77,6 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   initial commit
 
+[0.4.0]: https://github.com/linkFISH-Consulting/dbt-lf_utils/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/linkFISH-Consulting/dbt-lf_utils/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/linkFISH-Consulting/dbt-lf_utils/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/linkFISH-Consulting/dbt-lf_utils/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/linkFISH-Consulting/dbt-lf_utils/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - macro argumnet: `date_from_parts` and `datetime_from_parts` now accept static `'last'` as argument for `day`, to get the last day of the month.
 
+### Fixed
+
+- we should no longer get warnings for overriding the `generate_alias_name` and `generate_schema_name` builtin macros
+
 ## [0.3.0] - 2026-02-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - Upcoming
+
+### Added
+
+- macro argumnet: `date_from_parts` and `datetime_from_parts` now accept static `'last'` as argument for `day`, to get the last day of the month.
+
 ## [0.3.0] - 2026-02-04
 
 ### Added
@@ -70,4 +76,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.2]: https://github.com/linkFISH-Consulting/dbt-lf_utils/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/linkFISH-Consulting/dbt-lf_utils/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/linkFISH-Consulting/dbt-lf_utils/compare/v0.1.0...v0.2.0
-

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'lf_utils'
-version: '0.3.0'
+version: '0.4.0'
 require-dbt-version: [">=1.5.0", "<2.0.0"]
 
 profile: 'lf_utils_duckdb'

--- a/macros/_docstrings.yml
+++ b/macros/_docstrings.yml
@@ -1,4 +1,4 @@
-# this file is auto-generated. last updated: 2025-08-14 16:54:01
+# this file is auto-generated. last updated: 2026-05-20 14:18:41
 
 version: 2
 
@@ -15,6 +15,12 @@ macros:
   - name: get_months
     description: '{{ doc("macros__get_months") }}'
 
+  - name: filter
+    description: '{{ doc("macros__filter") }}'
+
+  - name: second
+    description: '{{ doc("macros__second") }}'
+
   - name: right
     description: '{{ doc("macros__right") }}'
 
@@ -23,6 +29,9 @@ macros:
 
   - name: month
     description: '{{ doc("macros__month") }}'
+
+  - name: day
+    description: '{{ doc("macros__day") }}'
 
   - name: is_numeric
     description: '{{ doc("macros__is_numeric") }}'
@@ -36,6 +45,15 @@ macros:
   - name: camel_to_snake
     description: '{{ doc("macros__camel_to_snake") }}'
 
+  - name: hour
+    description: '{{ doc("macros__hour") }}'
+
+  - name: minute
+    description: '{{ doc("macros__minute") }}'
+
+  - name: datetime_from_parts
+    description: '{{ doc("macros__datetime_from_parts") }}'
+
   - name: year
     description: '{{ doc("macros__year") }}'
 
@@ -45,11 +63,11 @@ macros:
   - name: date_to_string
     description: '{{ doc("macros__date_to_string") }}'
 
-  - name: generate_schema_name
-    description: '{{ doc("macros_patches__generate_schema_name") }}'
+  - name: default__generate_schema_name
+    description: '{{ doc("macros_patches__default__generate_schema_name") }}'
 
-  - name: generate_alias_name
-    description: '{{ doc("macros_patches__generate_alias_name") }}'
+  - name: default__generate_alias_name
+    description: '{{ doc("macros_patches__default__generate_alias_name") }}'
 
   - name: test_period_shift_is_consistent
     description: '{{ doc("macros_generic_tests__test_period_shift_is_consistent") }}'

--- a/macros/date_from_parts.sql
+++ b/macros/date_from_parts.sql
@@ -13,8 +13,8 @@ this can take integers, but also columns as input.
     The year to use, e.g. 2023
 - month : integer or column
     The month to use, e.g. 10 for October
-- day : integer or column
-    The day to use, e.g. 4 for the 4th of the month
+- day : integer, column, or the string "last"
+    The day to use, e.g. 4 for the 4th of the month, or "last" for the last day of the month
 
 # Example
 
@@ -34,31 +34,64 @@ endmacrodocs #}
 {%- macro default__date_from_parts(year, month, day) -%} {%- endmacro %}
 
 {%- macro duckdb__date_from_parts(year, month, day) %}
-    make_date(
-        cast({{ year }} as int), cast({{ month }} as int), cast({{ day }} as int)
-    )
+    {%- if day == 'last' %}
+        cast(
+            date_trunc(
+                'month', make_date(
+                    cast({{ year }} as int), cast({{ month }} as int), 1
+                )
+            )
+            + interval '1 month'
+            - interval '1 day' as date
+        )
+    {%- else %}
+        make_date(
+            cast({{ year }} as int), cast({{ month }} as int), cast({{ day }} as int)
+        )
+    {%- endif %}
 {%- endmacro %}
 
 {%- macro sqlserver__date_from_parts(year, month, day) %}
-    datefromparts(
-        cast({{ year }} as int), cast({{ month }} as int), cast({{ day }} as int)
-    )
+    {%- if day == 'last' %}
+        eomonth(datefromparts(cast({{ year }} as int), cast({{ month }} as int), 1))
+    {%- else %}
+        datefromparts(
+            cast({{ year }} as int), cast({{ month }} as int), cast({{ day }} as int)
+        )
+    {%- endif %}
 {%- endmacro %}
 
 {%- macro postgres__date_from_parts(year, month, day) %}
-    to_date(
-        cast({{ year }} as int)::text || '-' ||
-        cast({{ month }} as int)::text || '-' ||
-        cast({{ day }} as int)::text,
-        'YYYY-MM-DD'
-    )
+    {%- if day == 'last' %}
+        (
+            date_trunc('month', make_date(cast({{ year }} as int), cast({{ month }} as int), 1))
+            + interval '1 month - 1 day'
+        )::date
+    {%- else %}
+        to_date(
+            cast({{ year }} as int)::text || '-' ||
+            cast({{ month }} as int)::text || '-' ||
+            cast({{ day }} as int)::text,
+            'YYYY-MM-DD'
+        )
+    {%- endif %}
 {%- endmacro %}
 
 {%- macro oracle__date_from_parts(year, month, day) %}
-    to_date(
-        cast({{ year }} as int) || '-' ||
-        cast({{ month }} as int) || '-' ||
-        cast({{ day }} as int),
-        'YYYY-MM-DD'
-    )
+    {%- if day == 'last' %}
+        last_day(
+            to_date(
+                cast({{ year }} as int) || '-' ||
+                cast({{ month }} as int) || '-1',
+                'YYYY-MM-DD'
+            )
+        )
+    {%- else %}
+        to_date(
+            cast({{ year }} as int) || '-' ||
+            cast({{ month }} as int) || '-' ||
+            cast({{ day }} as int),
+            'YYYY-MM-DD'
+        )
+    {%- endif %}
 {%- endmacro %}

--- a/macros/datetime_from_parts.sql
+++ b/macros/datetime_from_parts.sql
@@ -13,8 +13,8 @@ This can take integers, but also columns as input.
     The year to use, e.g. 2023
 - month : integer or column
     The month to use, e.g. 10 for October
-- day : integer or column
-    The day to use, e.g. 4 for the 4th of the month
+- day : integer, column, or the string "last"
+    The day to use, e.g. 4 for the 4th of the month, or "last" for the last day of the month
 - hour: integer or column
     Hour, default 0
 - minute: integer or column
@@ -48,48 +48,121 @@ endmacrodocs #}
 {%- endmacro %}
 
 {%- macro duckdb__datetime_from_parts(year, month, day, hour, minute, second) %}
-    make_timestamp(
-        cast({{ year }} as int),
-        cast({{ month }} as int),
-        cast({{ day }} as int),
-        cast({{ hour }} as int),
-        cast({{ minute }} as int),
-        cast({{ second }} as numeric)
-    )
+    {%- if day == 'last' %}
+        make_timestamp(
+            cast({{ year }} as int),
+            cast({{ month }} as int),
+            cast(
+                extract(
+                    day from cast(
+                        date_trunc(
+                            'month', make_date(
+                                cast({{ year }} as int), cast({{ month }} as int), 1
+                            )
+                        )
+                        + interval '1 month'
+                        - interval '1 day' as date
+                    )
+                ) as int
+            ),
+            cast({{ hour }} as int),
+            cast({{ minute }} as int),
+            cast({{ second }} as numeric)
+        )
+    {%- else %}
+        make_timestamp(
+            cast({{ year }} as int),
+            cast({{ month }} as int),
+            cast({{ day }} as int),
+            cast({{ hour }} as int),
+            cast({{ minute }} as int),
+            cast({{ second }} as numeric)
+        )
+    {%- endif %}
 {%- endmacro %}
 
 {%- macro sqlserver__datetime_from_parts(year, month, day, hour, minute, second) %}
-    datetimefromparts(
-        cast({{ year }} as int),
-        cast({{ month }} as int),
-        cast({{ day }} as int),
-        cast({{ hour }} as int),
-        cast({{ minute }} as int),
-        cast({{ second }} as int),
-        0  -- millisecond
-    )
+    {%- if day == 'last' %}
+        datetimefromparts(
+            cast({{ year }} as int),
+            cast({{ month }} as int),
+            day(eomonth(datefromparts(cast({{ year }} as int), cast({{ month }} as int), 1))),
+            cast({{ hour }} as int),
+            cast({{ minute }} as int),
+            cast({{ second }} as int),
+            0  -- millisecond
+        )
+    {%- else %}
+        datetimefromparts(
+            cast({{ year }} as int),
+            cast({{ month }} as int),
+            cast({{ day }} as int),
+            cast({{ hour }} as int),
+            cast({{ minute }} as int),
+            cast({{ second }} as int),
+            0  -- millisecond
+        )
+    {%- endif %}
 {%- endmacro %}
 
 {%- macro postgres__datetime_from_parts(year, month, day, hour, minute, second) %}
-    to_timestamp(
-        cast({{ year }} as int)::text || '-' ||
-        cast({{ month }} as int)::text || '-' ||
-        cast({{ day }} as int)::text || ' ' ||
-        lpad(cast({{ hour }} as int)::text, 2, '0') || ':' ||
-        lpad(cast({{ minute }} as int)::text, 2, '0') || ':' ||
-        lpad(cast({{ second }} as numeric)::text, 2, '0'),
-        'YYYY-MM-DD HH24:MI:SS'
-    )
+    {%- if day == 'last' %}
+        to_timestamp(
+            cast({{ year }} as int)::text || '-' ||
+            cast({{ month }} as int)::text || '-' ||
+            extract(
+                day from (
+                    date_trunc('month', make_date(cast({{ year }} as int), cast({{ month }} as int), 1))
+                    + interval '1 month - 1 day'
+                )
+            )::int::text || ' ' ||
+            lpad(cast({{ hour }} as int)::text, 2, '0') || ':' ||
+            lpad(cast({{ minute }} as int)::text, 2, '0') || ':' ||
+            lpad(cast({{ second }} as numeric)::text, 2, '0'),
+            'YYYY-MM-DD HH24:MI:SS'
+        )
+    {%- else %}
+        to_timestamp(
+            cast({{ year }} as int)::text || '-' ||
+            cast({{ month }} as int)::text || '-' ||
+            cast({{ day }} as int)::text || ' ' ||
+            lpad(cast({{ hour }} as int)::text, 2, '0') || ':' ||
+            lpad(cast({{ minute }} as int)::text, 2, '0') || ':' ||
+            lpad(cast({{ second }} as numeric)::text, 2, '0'),
+            'YYYY-MM-DD HH24:MI:SS'
+        )
+    {%- endif %}
 {%- endmacro %}
 
 {%- macro oracle__datetime_from_parts(year, month, day, hour, minute, second) %}
-    to_date(
-        cast({{ year }} as int) || '-' ||
-        cast({{ month }} as int) || '-' ||
-        cast({{ day }} as int) || ' ' ||
-        lpad(cast({{ hour }} as int), 2, '0') || ':' ||
-        lpad(cast({{ minute }} as int), 2, '0') || ':' ||
-        lpad(cast({{ second }} as int), 2, '0'),
-        'YYYY-MM-DD HH24:MI:SS'
-    )
+    {%- if day == 'last' %}
+        to_date(
+            cast({{ year }} as int) || '-' ||
+            cast({{ month }} as int) || '-' ||
+            to_char(
+                last_day(
+                    to_date(
+                        cast({{ year }} as int) || '-' ||
+                        cast({{ month }} as int) || '-1',
+                        'YYYY-MM-DD'
+                    )
+                ),
+                'DD'
+            ) || ' ' ||
+            lpad(cast({{ hour }} as int), 2, '0') || ':' ||
+            lpad(cast({{ minute }} as int), 2, '0') || ':' ||
+            lpad(cast({{ second }} as int), 2, '0'),
+            'YYYY-MM-DD HH24:MI:SS'
+        )
+    {%- else %}
+        to_date(
+            cast({{ year }} as int) || '-' ||
+            cast({{ month }} as int) || '-' ||
+            cast({{ day }} as int) || ' ' ||
+            lpad(cast({{ hour }} as int), 2, '0') || ':' ||
+            lpad(cast({{ minute }} as int), 2, '0') || ':' ||
+            lpad(cast({{ second }} as int), 2, '0'),
+            'YYYY-MM-DD HH24:MI:SS'
+        )
+    {%- endif %}
 {%- endmacro %}

--- a/macros/docs/macros__date_from_parts.md
+++ b/macros/docs/macros__date_from_parts.md
@@ -8,8 +8,8 @@ this can take integers, but also columns as input.
     The year to use, e.g. 2023
 - month : integer or column
     The month to use, e.g. 10 for October
-- day : integer or column
-    The day to use, e.g. 4 for the 4th of the month
+- day : integer, column, or the string "last"
+    The day to use, e.g. 4 for the 4th of the month, or "last" for the last day of the month
 
 # Example
 

--- a/macros/docs/macros__datetime_from_parts.md
+++ b/macros/docs/macros__datetime_from_parts.md
@@ -1,0 +1,32 @@
+{% docs macros__datetime_from_parts %}
+
+Create a timestamp from year, month, day, hour, minute, second
+This can take integers, but also columns as input.
+
+# Arguments
+- year : integer or column
+    The year to use, e.g. 2023
+- month : integer or column
+    The month to use, e.g. 10 for October
+- day : integer, column, or the string "last"
+    The day to use, e.g. 4 for the 4th of the month, or "last" for the last day of the month
+- hour: integer or column
+    Hour, default 0
+- minute: integer or column
+    Minute, default 0
+- second: integer or column
+    Second, default 0
+
+# Example
+
+31 Dez 2023 at 16:04:00
+
+{% raw %}
+```sql
+select
+    {{ lf_utils.datetime_from_parts(2023, 12, 31, 16, 4) }} as via_integers,
+    {{ lf_utils.datetime_from_parts("year_col", 12, 31, 16, 4) }} as via_mixed,
+```
+{% endraw %}
+
+{% enddocs %}

--- a/macros/docs/macros__day.md
+++ b/macros/docs/macros__day.md
@@ -1,0 +1,19 @@
+{% docs macros__day %}
+Extract the day as an integer from a date or timestamp column.
+
+# Arguments
+- from_date_or_timestamp : date or timestamp
+    The column or expression containing the date or timestamp.
+
+# Example
+{% raw %}
+```sql
+-- Extract day from a date column
+{{ lf_utils.day('my_date_column') }}
+```
+{% endraw %}
+
+# Notes
+- See also `lf_utils.date_strftime` for more flexible date formatting.
+
+{% enddocs %}

--- a/macros/docs/macros__filter.md
+++ b/macros/docs/macros__filter.md
@@ -1,0 +1,28 @@
+{% docs macros__filter %}
+
+Filter to use in where conditions, to check a column is in a provided array.
+
+If the provided list is empty or not defined, the filter will always be true (1=1).
+
+# Arguments
+- col : string
+    The column to filter, usually 'table.column'
+- in_values : list
+    List of values to filter for, usually a variable.
+- not_in_values : list
+    List of values to filter against (NOT IN), usually a variable.
+
+# Example
+{% raw %}
+```sql
+
+select
+    col_1
+from
+    my_table
+where
+    {{ lf_utils.filter(col='my_table.col_1', in_values=[1,2,3]) }}
+
+```
+{% endraw %}
+{% enddocs %}

--- a/macros/docs/macros__hour.md
+++ b/macros/docs/macros__hour.md
@@ -1,0 +1,21 @@
+{% docs macros__hour %}
+Extract the hour as an integer from a date or timestamp column.
+
+Returns 0 when the passed object is a date (instead of a timestamp).
+
+# Arguments
+- from_date_or_timestamp : date or timestamp
+    The column or expression containing the date or timestamp.
+
+# Example
+{% raw %}
+```sql
+-- Extract hour from a timestamp column
+{{ lf_utils.hour('my_timestamp_column') }}
+```
+{% endraw %}
+
+# Notes
+- See also `lf_utils.date_strftime` for more flexible date formatting.
+
+{% enddocs %}

--- a/macros/docs/macros__lpad.md
+++ b/macros/docs/macros__lpad.md
@@ -6,6 +6,7 @@ Pad a string-column on the left with a specified character to a given length.
     The column holding the text to be padded
 - len : integer or integer column
     The target length of the padded string. Cannot be negative.
+    If length is smaller than text, we truncate! See example.
 - padding : string
     The character to pad with.
 

--- a/macros/docs/macros__minute.md
+++ b/macros/docs/macros__minute.md
@@ -1,0 +1,21 @@
+{% docs macros__minute %}
+Extract the minute as an integer from a date or timestamp column.
+
+Returns 0 when the passed object is a date (instead of a timestamp).
+
+# Arguments
+- from_date_or_timestamp : date or timestamp
+    The column or expression containing the date or timestamp.
+
+# Example
+{% raw %}
+```sql
+-- Extract minute from a timestamp column
+{{ lf_utils.minute('my_timestamp_column') }}
+```
+{% endraw %}
+
+# Notes
+- See also `lf_utils.date_strftime` for more flexible date formatting.
+
+{% enddocs %}

--- a/macros/docs/macros__second.md
+++ b/macros/docs/macros__second.md
@@ -1,0 +1,22 @@
+{% docs macros__second %}
+Extract the second as an integer from a date or timestamp column.
+
+Returns 0 when the passed object is a date (instead of a timestamp).
+
+
+# Arguments
+- from_date_or_timestamp : date or timestamp
+    The column or expression containing the date or timestamp.
+
+# Example
+{% raw %}
+```sql
+-- Extract second from a timestamp column
+{{ lf_utils.second('my_timestamp_column') }}
+```
+{% endraw %}
+
+# Notes
+- See also `lf_utils.date_strftime` for more flexible date formatting.
+
+{% enddocs %}

--- a/macros/docs/macros_patches__default__generate_alias_name.md
+++ b/macros/docs/macros_patches__default__generate_alias_name.md
@@ -1,0 +1,14 @@
+{% docs macros_patches__default__generate_alias_name %}
+
+**Automatically invoked by dbt**, does not need to be called.
+[Check disptach search order](https://docs.getdbt.com/reference/dbt-jinja-functions/dispatch#overriding-global-macros)
+
+Overwrite the default way dbt generates the alias from the model file name.
+
+- The alias is the name that will occur as the table name in the database.
+- We remove everything until including the double underscore `__` which we
+  use as prefix for model file names to represent the folder structure.
+- For example: `int_huh_sup__pos_monat_erg.sql` -> `pos_monat_erg`
+- Supports model versions
+
+{% enddocs %}

--- a/macros/docs/macros_patches__default__generate_schema_name.md
+++ b/macros/docs/macros_patches__default__generate_schema_name.md
@@ -1,0 +1,11 @@
+{% docs macros_patches__default__generate_schema_name %}
+
+**Automatically invoked by dbt**, does not need to be called.
+[Check disptach search order](https://docs.getdbt.com/reference/dbt-jinja-functions/dispatch#overriding-global-macros)
+
+This macro prepends the target as a prefix for to the schema of tables and views
+that will materialize in the database - for all targets except 'prod'.
+
+In particular, the dev target gets a dev_ prefix, while the prod target is NOT prefixed
+
+{% enddocs %}

--- a/macros/lpad.sql
+++ b/macros/lpad.sql
@@ -1,7 +1,7 @@
 {# ------------------------------------------------------------------------------
 @Author:        F. Paul Spitzner
 @Created:       2025-08-14 13:51:11
-@Last Modified: 2025-08-14 14:54:06
+@Last Modified: 2026-03-18 17:17:51
 ------------------------------------------------------------------------------ #}
 
 {# macrodocs
@@ -12,6 +12,7 @@ Pad a string-column on the left with a specified character to a given length.
     The column holding the text to be padded
 - len : integer or integer column
     The target length of the padded string. Cannot be negative.
+    If length is smaller than text, we truncate! See example.
 - padding : string
     The character to pad with.
 

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,6 +1,4 @@
 packages:
-  - package: yu-iskw/dbt_unittest
-    version: 0.5.0
   - package: dbt-labs/dbt_utils
     version: 1.3.3
-sha1_hash: 9f2f8e50f6b0e23703a22ae9bf6a9b6075464c7d
+sha1_hash: 5ffdb7983bbd653b524c5344daf6cb5fd9eaf293

--- a/packages.yml
+++ b/packages.yml
@@ -1,5 +1,3 @@
 packages:
-  - package: yu-iskw/dbt_unittest
-    version: 0.5.0
   - package: dbt-labs/dbt_utils
     version: 1.3.3

--- a/unit_tests/models/ut_date_from_parts.sql
+++ b/unit_tests/models/ut_date_from_parts.sql
@@ -25,3 +25,9 @@ union all
 -- Test edge case: last day of year
 select {{ lf_utils.date_from_parts(2023, 12, 31) }} as output
 from {{ ref("_dummy_source") }}
+
+union all
+
+-- Test "last" day argument
+select {{ lf_utils.date_from_parts(2023, 2, "last") }} as output
+from {{ ref("_dummy_source") }}

--- a/unit_tests/models/ut_date_from_parts.yml
+++ b/unit_tests/models/ut_date_from_parts.yml
@@ -17,3 +17,5 @@ unit_tests:
         - {output: "2024-02-29"}
         # Test last day of year
         - {output: "2023-12-31"}
+        # Test last day argument
+        - {output: "2023-02-28"}

--- a/unit_tests/models/ut_datetime_from_parts.sql
+++ b/unit_tests/models/ut_datetime_from_parts.sql
@@ -36,3 +36,9 @@ union all
 -- Test time default values
 select {{ lf_utils.datetime_from_parts(2023, 12, 31) }} as output
 from {{ ref("_dummy_source") }}
+
+union all
+
+-- Test "last" day argument
+select {{ lf_utils.date_from_parts(2023, 2, "last") }} as output
+from {{ ref("_dummy_source") }}

--- a/unit_tests/models/ut_datetime_from_parts.yml
+++ b/unit_tests/models/ut_datetime_from_parts.yml
@@ -19,3 +19,5 @@ unit_tests:
         - {output: "2023-12-31 16:04:00"}
         # Test default values of time
         - {output: "2023-12-31 00:00:00"}
+        # Test last day argument
+        - {output: "2023-02-28 00:00:00"}


### PR DESCRIPTION

## [0.4.0] - 2026-06-17

### Added

- macro argumnet: `date_from_parts` and `datetime_from_parts` now accept static `'last'` as argument for `day`, to get the last day of the month.

### Fixed

- we should no longer get warnings for overriding the `generate_alias_name` and `generate_schema_name` builtin macros

### Removed

- `dbt_unittest` dependency, in the end we never used it.